### PR TITLE
Add CI test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        node-version: [20.x, 22.x, 24.x, 25.x]
+      fail-fast: false
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
+      - name: Use Nodejs ${{ matrix.node-version }}
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run Tests
+        run: npm test


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml` copied from the node-feedparser repo
- Runs tests against Node.js 20.x, 22.x, 24.x, and 25.x (v10 excluded)
- Triggers on push and manual dispatch

https://claude.ai/code/session_01FdK9HLyrvjvuzqpmFSdXaA